### PR TITLE
Build skeleton app by Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/.idea
+/NOTES.md
+/tmp
+/logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 !/.idea
 !/.idea/**/*
 /NOTES.md
+/.env.*.local

--- a/.idea/runConfigurations/build_run.xml
+++ b/.idea/runConfigurations/build_run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="build+run" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
+    <deployment type="dockerfile">
+      <settings>
+        <option name="imageTag" value="donotdrivenow:dev" />
+        <option name="buildCliOptions" value="--progress plain" />
+        <option name="containerName" value="donotdrive-dev" />
+        <option name="commandLineOptions" value="--rm --add-host host.docker.internal:host-gateway --env-file .env.dev.local" />
+        <option name="showCommandPreview" value="true" />
+        <option name="sourceFilePath" value="Dockerfile" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.12-alpine
+
+# Increase to expire all following cached layers
+ENV expire_caches=20240511
+
+RUN --mount=type=cache,target=/var/cache/apk <<EOL
+apk update
+apk add gcc musl-dev libffi-dev python3-dev
+adduser -D app -u 1000
+EOL
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=off \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    PIP_DEFAULT_TIMEOUT=100 \
+    POETRY_CACHE_DIR=/app/.pypoetry-cache
+
+RUN pip install --upgrade pip && \
+    pip install 'poetry~=1.8'
+
+USER 1000:1000
+WORKDIR /app
+
+COPY --chown=1000:1000 poetry.lock pyproject.toml ./
+
+RUN poetry install
+
+COPY --chown=1000:1000 . ./
+
+ENTRYPOINT ["poetry", "run", "litestar", "run", "-H", "0.0.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,5 @@
 [tool.poetry]
-name = "donotdrivenow"
-version = "1.0.0"
-description = ""
-authors = ["Asfand Qazi <ayqazi@gmail.com>"]
-readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"

--- a/test_main.http
+++ b/test_main.http
@@ -1,6 +1,0 @@
-# Test your FastAPI endpoints
-
-GET http://127.0.0.1:8000/drive_now?location=Leicester
-Accept: application/json
-
-###


### PR DESCRIPTION
Can be built and connected to a locally running postgreSQL instance by env var:

```
docker run --name donotdrive-dev --env-file .env.dev.local --add-host host.docker.internal:host-gateway --rm -p 8000:8000 donotdrivenow:dev
```

with `.env.dev.local` containing something like:
```sh
DB_URI=postgresql+asyncpg://USERNAME@host.docker.internal/donotdrivenow_dev
```